### PR TITLE
fix: normalize decimal inputs swapped on settlement

### DIFF
--- a/packages/contracts/solana-spoke/programs/everclear_spoke/src/instructions/receive_message.rs
+++ b/packages/contracts/solana-spoke/programs/everclear_spoke/src/instructions/receive_message.rs
@@ -283,10 +283,9 @@ fn handle_settlement<'info>(
     let mint_account = Account::<Mint>::try_from(mint_info)?;
     let minted_decimals = mint_account.decimals;
     let amount = normalize_decimals(
-        // TODO: type check this amount properly for edge cases
         settlement.amount.low_u64(),
-        minted_decimals,
         DEFAULT_NORMALIZED_DECIMALS,
+        minted_decimals,
     )?;
     if amount == 0 {
         return Ok(None);


### PR DESCRIPTION
Fixing the decimal conversion issue highlighted by Oshield when receiving settlement.
    