### PR TITLE
fix: move cpi event filtering to pipeline

### DIFF
--- a/packages/adapters/database/db/migrations/20250415125459_solana_cpi_events_trigger.sql
+++ b/packages/adapters/database/db/migrations/20250415125459_solana_cpi_events_trigger.sql
@@ -1,0 +1,51 @@
+-- migrate:up
+
+DROP TRIGGER process_cpi_events_trigger ON solana.solana_spoke_instructions;
+DROP FUNCTION IF EXISTS public.process_cpi_events();
+
+CREATE OR REPLACE FUNCTION public.process_cpi_events() RETURNS TRIGGER AS $$
+DECLARE
+	res BOOLEAN;
+BEGIN
+    IF NEW.tx_status = 1 AND NEW.tx_err = 'null' THEN
+        res := parse_and_insert_cpi_event(NEW);
+        IF res IS FALSE THEN
+            RAISE WARNING 'Failed to parse and insert CPI event for transaction %', NEW.tx_signature;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;$$
+LANGUAGE PLPGSQL
+SECURITY DEFINER
+SET search_path = solana, public;
+
+CREATE TRIGGER process_cpi_events_trigger BEFORE INSERT OR UPDATE ON solana.solana_spoke_instructions
+FOR EACH ROW EXECUTE FUNCTION public.process_cpi_events();
+
+-- migrate:down
+
+DROP TRIGGER process_cpi_events_trigger ON solana.solana_spoke_instructions;
+DROP FUNCTION IF EXISTS public.process_cpi_events();
+
+CREATE OR REPLACE FUNCTION public.process_cpi_events() RETURNS TRIGGER AS $$
+DECLARE
+	res BOOLEAN;
+BEGIN
+    IF NEW.accounts = '["3RaCiTPYkAQPg61JVdfbxSp9V4tsw8ZuARtFMdQfNaMp"]'
+           AND NEW.tx_status = 1 AND NEW.tx_err = 'null' THEN
+        res := parse_and_insert_cpi_event(NEW);
+        IF res IS FALSE THEN
+            RAISE WARNING 'Failed to parse and insert CPI event for transaction %', NEW.tx_signature;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;$$
+LANGUAGE PLPGSQL
+SECURITY DEFINER
+SET search_path = solana, public;
+
+CREATE TRIGGER process_cpi_events_trigger BEFORE INSERT OR UPDATE ON solana.solana_spoke_instructions
+FOR EACH ROW EXECUTE FUNCTION public.process_cpi_events();
+

--- a/packages/adapters/database/db/schema.sql
+++ b/packages/adapters/database/db/schema.sql
@@ -661,8 +661,7 @@ CREATE FUNCTION public.process_cpi_events() RETURNS trigger
 DECLARE
 	res BOOLEAN;
 BEGIN
-    IF NEW.accounts = '["HoUvmo3eC8gwMknYvyhto8S8iT8xZryUdErfXhawoHeG"]'
-           AND NEW.tx_status = 1 AND NEW.tx_err = 'null' THEN
+    IF NEW.tx_status = 1 AND NEW.tx_err = 'null' THEN
         res := parse_and_insert_cpi_event(NEW);
         IF res IS FALSE THEN
             RAISE WARNING 'Failed to parse and insert CPI event for transaction %', NEW.tx_signature;
@@ -4902,4 +4901,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20250322012505'),
     ('20250325230805'),
     ('20250410040210'),
-    ('20250411120150');
+    ('20250411120150'),
+    ('20250415125459');


### PR DESCRIPTION
Solana cpi event authority depends on the solana spoke address and is different for different envs. Filtering goldsky dataset by cpi event authority can be done in the pipeline, this way there will be the same trigger code in all branches.