### PR TITLE
fix: update of solana settlement data in db

### DIFF
--- a/packages/adapters/database/db/migrations/20250418195903_solana_settlement_tx_origin.sql
+++ b/packages/adapters/database/db/migrations/20250418195903_solana_settlement_tx_origin.sql
@@ -1,0 +1,146 @@
+-- migrate:up
+
+CREATE OR REPLACE FUNCTION public.parse_and_insert_delivered_cpi_event(hex_data TEXT, rec record) RETURNS BOOLEAN AS $$
+DECLARE
+    intent_id TEXT;
+    recipient TEXT;
+    asset TEXT;
+    domain INT;
+    pos INT := 33;
+BEGIN
+    domain := to_int(reverse_bytes(SUBSTRING(hex_data, pos, 8)));
+    pos := pos + 8;
+    intent_id := '0x' || SUBSTRING(hex_data, pos, 64);
+    pos := pos + 64 + 64; -- skip amount
+    asset := '0x' || SUBSTRING(hex_data, pos, 64);
+    pos := pos + 64;
+    recipient := '0x' || SUBSTRING(hex_data, pos, 64);
+    pos := pos + 64;
+
+    INSERT INTO public.settlement_intents(
+        id,
+        amount,
+        asset,
+        recipient,
+        domain,
+        transaction_hash,
+        "timestamp",
+        block_number,
+        tx_origin,
+        tx_nonce,
+        gas_limit,
+        gas_price,
+        return_data,
+        status
+    )
+    VALUES (
+        intent_id,
+        0,
+        asset,
+        recipient,
+        domain,
+        rec.tx_signature,
+        rec.block_timestamp,
+        rec.block_slot,
+        recipient,
+        0,
+        rec.tx_fee,
+        1,
+        '0x',
+        'DELIVERED'
+    )
+    ON CONFLICT (id)
+        DO UPDATE SET
+            amount = EXCLUDED.amount,
+            asset = EXCLUDED.asset,
+            recipient = EXCLUDED.recipient,
+            domain = EXCLUDED.domain,
+            transaction_hash = EXCLUDED.transaction_hash,
+            "timestamp" = EXCLUDED."timestamp",
+            block_number = EXCLUDED.block_number,
+            tx_origin = EXCLUDED.tx_origin,
+            tx_nonce = EXCLUDED.tx_nonce,
+            gas_limit = EXCLUDED.gas_limit,
+            gas_price = EXCLUDED.gas_price,
+            return_data = EXCLUDED.return_data,
+            status = EXCLUDED.status;
+
+    RETURN TRUE;
+END;$$
+    LANGUAGE PLPGSQL;
+
+CREATE OR REPLACE FUNCTION public.parse_and_insert_settled_cpi_event(hex_data TEXT, rec record) RETURNS BOOLEAN AS $$
+DECLARE
+    intent_id TEXT;
+    recipient TEXT;
+    asset TEXT;
+    amount NUMERIC;
+    domain INT;
+	pos INT := 33;
+BEGIN
+	intent_id := '0x' || SUBSTRING(hex_data, pos, 64);
+	pos := pos + 64;
+	recipient := '0x' || SUBSTRING(hex_data, pos, 64);
+	pos := pos + 64;
+	asset := '0x' || SUBSTRING(hex_data, pos, 64);
+	pos := pos + 64;
+	amount := to_numeric(reverse_bytes(SUBSTRING(hex_data, pos, 16)));
+	pos := pos + 16;
+	domain := to_int(reverse_bytes(SUBSTRING(hex_data, pos, 8)));
+	pos := pos + 8;
+
+	INSERT INTO public.settlement_intents(
+		id,
+		amount,
+		asset,
+		recipient,
+		domain,
+		transaction_hash,
+		"timestamp",
+		block_number,
+		tx_origin,
+		tx_nonce,
+		gas_limit,
+		gas_price,
+		return_data,
+		status
+	)
+	VALUES (
+		intent_id,
+		amount,
+		asset,
+		recipient,
+		domain,
+        rec.tx_signature,
+		rec.block_timestamp,
+		rec.block_slot,
+		recipient,
+		0,
+		rec.tx_fee,
+		1,
+		'0x',
+		'SETTLED'
+	)
+	ON CONFLICT (id)
+	DO UPDATE SET
+		amount = EXCLUDED.amount,
+		asset = EXCLUDED.asset,
+		recipient = EXCLUDED.recipient,
+		domain = EXCLUDED.domain,
+		transaction_hash = EXCLUDED.transaction_hash,
+		"timestamp" = EXCLUDED."timestamp",
+		block_number = EXCLUDED.block_number,
+		tx_origin = EXCLUDED.tx_origin,
+		tx_nonce = EXCLUDED.tx_nonce,
+		gas_limit = EXCLUDED.gas_limit,
+		gas_price = EXCLUDED.gas_price,
+		return_data = EXCLUDED.return_data,
+		status = EXCLUDED.status;
+
+    RETURN TRUE;
+END;$$
+LANGUAGE PLPGSQL;
+
+
+-- migrate:down
+

--- a/packages/adapters/database/db/schema.sql
+++ b/packages/adapters/database/db/schema.sql
@@ -395,7 +395,7 @@ BEGIN
         rec.tx_signature,
         rec.block_timestamp,
         rec.block_slot,
-        '',
+        recipient,
         0,
         rec.tx_fee,
         1,
@@ -614,7 +614,7 @@ BEGIN
         rec.tx_signature,
 		rec.block_timestamp,
 		rec.block_slot,
-		'',
+		recipient,
 		0,
 		rec.tx_fee,
 		1,
@@ -4911,4 +4911,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20250415204003'),
     ('20250416224500'),
     ('20250417163412'),
-    ('20250418160651');
+    ('20250418160651'),
+    ('20250418195903');

--- a/packages/adapters/database/src/client.ts
+++ b/packages/adapters/database/src/client.ts
@@ -855,3 +855,12 @@ export const getDeliveredSettlements = async (
   const result = await db.select('settlement_intents', { status: TIntentStatus.Delivered, domain }).run(poolToUse);
   return result.map(converters.fromSettlementIntents);
 };
+
+export const updateSettlementStatus = async (
+  intentId: string,
+  status: s.intent_status,
+  _pool?: Pool | db.TxnClientForRepeatableRead,
+) => {
+  const poolToUse = _pool ?? pool;
+  await db.update('settlement_intents', { status }, { id: intentId }).run(poolToUse);
+};

--- a/packages/adapters/database/src/index.ts
+++ b/packages/adapters/database/src/index.ts
@@ -85,6 +85,7 @@ import {
   getOrders,
   getOriginIntentsLastNonce,
   getDeliveredSettlements,
+  updateSettlementStatus,
 } from './client';
 import { hub_intents, intent_status, message_status } from 'zapatos/schema';
 
@@ -264,6 +265,11 @@ export type Database = {
   getOrders: (orderIds: string[], _pool?: Pool | TxnClientForRepeatableRead) => Promise<Order[]>;
   getOriginIntentsLastNonce: (origin: string, _pool?: Pool | TxnClientForRepeatableRead) => Promise<number>;
   getDeliveredSettlements: (domain: string, _pool?: Pool | TxnClientForRepeatableRead) => Promise<SettlementIntent[]>;
+  updateSettlementStatus: (
+    intentId: string,
+    status: intent_status,
+    _pool?: Pool | TxnClientForRepeatableRead,
+  ) => Promise<void>;
 };
 
 export let pool: Pool;
@@ -335,6 +341,7 @@ export const getDatabase = async (databaseUrl: string, logger: Logger): Promise<
     getOrders,
     getOriginIntentsLastNonce,
     getDeliveredSettlements,
+    updateSettlementStatus,
   };
 };
 

--- a/packages/adapters/database/test/client.spec.ts
+++ b/packages/adapters/database/test/client.spec.ts
@@ -50,6 +50,7 @@ import {
   getLockPositions,
   getOriginIntentsLastNonce,
   getDeliveredSettlements,
+  updateSettlementStatus,
 } from '../src/client';
 import {
   expect,
@@ -1008,6 +1009,24 @@ describe('Database Adapter:Client', () => {
       // Verify only DELIVERED intents that belong to the set domain are returned
       const result = await getDeliveredSettlements('1399811149', pool);
       expect(result).to.be.deep.eq(deliveredIntents);
+    });
+  });
+
+  describe('#updateSettlementStatus', () => {
+    const intents = createSettlementIntents(2, [
+      { intentId: mkBytes32('0x1'), status: TIntentStatus.Delivered, domain: '1339' },
+      { intentId: mkBytes32('0x2'), status: TIntentStatus.Delivered, domain: '1340' },
+    ]);
+
+    const expectedIntents = createSettlementIntents(1, [
+      { intentId: mkBytes32('0x1'), status: TIntentStatus.Settled, domain: '1339' },
+    ]);
+
+    it('should work', async () => {
+      await saveSettlementIntents(intents, pool);
+      expect(await getSettlementIntentsByStatus(TIntentStatus.Settled, pool)).to.be.empty;
+      await updateSettlementStatus(mkBytes32('0x1'), TIntentStatus.Settled, pool);
+      expect(await getSettlementIntentsByStatus(TIntentStatus.Settled, pool)).to.be.deep.eq(expectedIntents);
     });
   });
 });

--- a/packages/agents/lighthouse/src/tasks/solana/processSolanaTransactions.ts
+++ b/packages/agents/lighthouse/src/tasks/solana/processSolanaTransactions.ts
@@ -105,7 +105,8 @@ export const processSolanaTransactions = async () => {
 
       await anchor.web3.sendAndConfirmTransaction(connection, transaction, [signer], { maxRetries: MAX_RETRIES });
 
-      settlement.status = TIntentStatus.Settled;
+      // Update the status of the settlement in the database
+      await database.updateSettlementStatus(settlement.intentId, TIntentStatus.Settled);
     } catch (error) {
       logger.error('Failed to settle intent', requestContext, methodContext, {
         message: error instanceof Error ? error.message : String(error),
@@ -115,9 +116,6 @@ export const processSolanaTransactions = async () => {
       }); // Continue to the next settlement
     }
   }
-
-  // Update the status of the settlements in the database
-  await database.saveSettlementIntents(settlements);
 
   logger.info('Completed processing Solana settlements', requestContext, methodContext);
 };


### PR DESCRIPTION
- fill solana settlement tx_origin
- settlement cpi event values may be overwritten by old settlement values cached in LH, if solana pipeline delivers cpi event quicker than LH updates settelement in db. To fix this LH only update the status of the settlement rather than updating all columns