### PR TITLE
fix: filter out Solana chain messages in monitor bindings and message…

### DIFF
--- a/packages/agents/monitor/src/bindings/index.ts
+++ b/packages/agents/monitor/src/bindings/index.ts
@@ -17,7 +17,7 @@ import {
   HyperlaneMessageSummary,
   HyperlaneMessageSummarySchema,
 } from '../types/api';
-import { createLoggingContext, jsonifyError } from '@chimera-monorepo/utils';
+import { createLoggingContext, jsonifyError, SOLANA_CHAINID } from '@chimera-monorepo/utils';
 import { getIntentStatus } from '../checklist/queue';
 import { getContext } from '../context';
 import { getAssetConfig, getTokenPrice, selfRelayHyperlaneMessages } from '../libs';
@@ -55,7 +55,7 @@ export const bindServer = async (): Promise<FastifyInstance> => {
         const { originDomain, destinationDomains, intentId } = request.params;
         const messages = await getIntentStatus(
           originDomain,
-          destinationDomains.split(',').filter((d) => d !== originDomain),
+          destinationDomains.split(',').filter((d) => d !== originDomain && d !== SOLANA_CHAINID),
           intentId,
         );
         logger.debug('Retrieved message status for intent', requestContext, methodContext, { intentId, messages });

--- a/packages/agents/monitor/src/checklist/queue/message.ts
+++ b/packages/agents/monitor/src/checklist/queue/message.ts
@@ -1,4 +1,4 @@
-import { HyperlaneStatus, createLoggingContext, getNtpTimeSeconds } from '@chimera-monorepo/utils';
+import { HyperlaneStatus, SOLANA_CHAINID, createLoggingContext, getNtpTimeSeconds } from '@chimera-monorepo/utils';
 import { getContext } from '../../context';
 import { getMessageStatus } from '../../helpers';
 import { IntentMessageSummary, Severity } from '../../types';
@@ -58,7 +58,9 @@ export const checkMessageStatus = async (shouldAlert = true) => {
   let offset = 0;
   const messagesToAlert: string[] = [];
   while (!end) {
-    const uncompletedMessages = await database.getMessagesByStatus(uncompletedStatuses, offset, limit);
+    const uncompletedDbMessages = await database.getMessagesByStatus(uncompletedStatuses, offset, limit);
+    // TODO: Remove this once Solana chain messages are supported by pipeline triggers
+    const uncompletedMessages = uncompletedDbMessages.filter((message) => message.destinationDomain === SOLANA_CHAINID);
     logger.debug('Getting hyperlane message status', requestContext, methodContext, {
       offset,
       limit,

--- a/packages/agents/monitor/src/checklist/queue/message.ts
+++ b/packages/agents/monitor/src/checklist/queue/message.ts
@@ -60,7 +60,7 @@ export const checkMessageStatus = async (shouldAlert = true) => {
   while (!end) {
     const uncompletedDbMessages = await database.getMessagesByStatus(uncompletedStatuses, offset, limit);
     // TODO: Remove this once Solana chain messages are supported by pipeline triggers
-    const uncompletedMessages = uncompletedDbMessages.filter((message) => message.destinationDomain === SOLANA_CHAINID);
+    const uncompletedMessages = uncompletedDbMessages.filter((message) => message.destinationDomain !== SOLANA_CHAINID);
     logger.debug('Getting hyperlane message status', requestContext, methodContext, {
       offset,
       limit,


### PR DESCRIPTION
This pull request introduces changes to filter out messages related to the Solana chain (`SOLANA_CHAINID`) in the `monitor` package. The updates primarily ensure that Solana-related messages are excluded from processing until full support is implemented. Below are the key changes:

### Enhancements to filtering logic:

* [`packages/agents/monitor/src/bindings/index.ts`](diffhunk://#diff-9c335aa2b0845f34f3b9547104d65a0fca3b881157c081b54cebac92c6b1650aL58-R58): Updated the `getIntentStatus` function to exclude `SOLANA_CHAINID` from the list of destination domains when retrieving message statuses.

* [`packages/agents/monitor/src/checklist/queue/message.ts`](diffhunk://#diff-1b49b2e20c104e12a75b9a2f7bcdaf197d12cebc69e3db8520d9e210d3ec2c2aL61-R63): Added a filter in the `checkMessageStatus` function to exclude messages with `destinationDomain` set to `SOLANA_CHAINID`. A `TODO` comment was also added to indicate that this is a temporary measure until Solana chain messages are supported.

### Dependency updates:

* `packages/agents/monitor/src/bindings/index.ts` and `packages/agents/monitor/src/checklist/queue/message.ts`: Imported `SOLANA_CHAINID` from the shared utilities module (`@chimera-monorepo/utils`) to enable the new filtering logic. [[1]](diffhunk://#diff-9c335aa2b0845f34f3b9547104d65a0fca3b881157c081b54cebac92c6b1650aL20-R20) [[2]](diffhunk://#diff-1b49b2e20c104e12a75b9a2f7bcdaf197d12cebc69e3db8520d9e210d3ec2c2aL1-R1)
    