### PR TITLE
fix: bump amazon rabbitmq version to 3.13 as 3.12 is out of support

### DIFF
--- a/ops/modules/amq/main.tf
+++ b/ops/modules/amq/main.tf
@@ -2,7 +2,7 @@ resource "aws_mq_broker" "default" {
   broker_name         = "rmq-cluster-${var.environment}-${var.stage}"
   deployment_mode     = var.deployment_mode
   engine_type         = "RabbitMQ"
-  engine_version      = "3.12.13"
+  engine_version      = "3.13"
   host_instance_type  = var.host_instance_type
   publicly_accessible = var.publicly_accessible
   subnet_ids          = var.publicly_accessible ? [] : var.subnet_ids
@@ -29,6 +29,3 @@ resource "aws_mq_broker" "default" {
     password = var.rmq_mgt_password
   }
 }
-
-
-


### PR DESCRIPTION
Currently deployment is blocked as RabbitMQ 3.12 is out of support (https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-version-management.html) and the MQ is automatically upgraded to 3.13.

Resolving the following error:
```
│ Error: updating MQ Broker (...) configuration: operation error mq: UpdateBroker, https response error StatusCode: 400, RequestID: ..., BadRequestException: Broker engine version [3.12.13] is invalid for broker engine type [RABBITMQ]. Valid values: [3.13].
│ 
│   with module.centralised_message_queue.aws_mq_broker.default,
│   on ../../../modules/amq/main.tf line 1, in resource "aws_mq_broker" "default":
│    1: resource "aws_mq_broker" "default" {
│ 
```