### PR TITLE
fix: set auto_minor_version_upgrade in aws_mq_broker as required

### DIFF
--- a/ops/modules/amq/main.tf
+++ b/ops/modules/amq/main.tf
@@ -3,6 +3,7 @@ resource "aws_mq_broker" "default" {
   deployment_mode     = var.deployment_mode
   engine_type         = "RabbitMQ"
   engine_version      = "3.13"
+  auto_minor_version_upgrade = true # required by RabbitMQ 3.13+
   host_instance_type  = var.host_instance_type
   publicly_accessible = var.publicly_accessible
   subnet_ids          = var.publicly_accessible ? [] : var.subnet_ids


### PR DESCRIPTION
As of RabbitMQ 3.13+, Amazon MQ now requires every MQ to be set with autoMinorVersionUpgrade or an error would occurs.

This also needed to be synced with the AWS config (i.e. there is no way of setting it only via terraform now, see the issue https://github.com/hashicorp/terraform-provider-aws/issues/40806)

Note for other instances, the parameter needed to be upgrade via the CLI (Management console do not work as it is defaulted true, but apparently you need this to make terraform satisfy):
`aws mq update-broker --broker-id <broker-id> --auto-minor-version-upgrade`