### PR TITLE
feat: update settlement calls as in latest prod

### DIFF
--- a/packages/agents/lighthouse/src/idl/everclear_spoke.json
+++ b/packages/agents/lighthouse/src/idl/everclear_spoke.json
@@ -764,6 +764,13 @@
           "name": "mint_account"
         },
         {
+          "name": "associated_token_program",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "recipient"
+        },
+        {
           "name": "recipient_token_account",
           "writable": true
         },
@@ -1831,7 +1838,7 @@
           },
           {
             "name": "normalized_amount",
-            "type": "u64"
+            "type": "u128"
           },
           {
             "name": "max_fee",

--- a/packages/agents/lighthouse/src/tasks/solana/processSolanaTransactions.ts
+++ b/packages/agents/lighthouse/src/tasks/solana/processSolanaTransactions.ts
@@ -103,8 +103,10 @@ export const processSolanaTransactions = async () => {
             tokenProgram: intentStatus.accounts[3].pubkey,
             systemProgram: intentStatus.accounts[4].pubkey,
             mintAccount: intentStatus.accounts[5].pubkey,
-            recipientTokenAccount: intentStatus.accounts[6].pubkey,
-            vaultTokenAccount: intentStatus.accounts[7].pubkey,
+            associatedTokenProgram: intentStatus.accounts[6].pubkey,
+            recipient: intentStatus.accounts[7].pubkey,
+            recipientTokenAccount: intentStatus.accounts[8].pubkey,
+            vaultTokenAccount: intentStatus.accounts[9].pubkey,
           })
           .instruction(),
       );

--- a/packages/utils/src/types/everclear_spoke.ts
+++ b/packages/utils/src/types/everclear_spoke.ts
@@ -770,6 +770,13 @@ export type EverclearSpoke = {
           "name": "mintAccount"
         },
         {
+          "name": "associatedTokenProgram",
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        },
+        {
+          "name": "recipient"
+        },
+        {
           "name": "recipientTokenAccount",
           "writable": true
         },
@@ -1837,7 +1844,7 @@ export type EverclearSpoke = {
           },
           {
             "name": "normalizedAmount",
-            "type": "u64"
+            "type": "u128"
           },
           {
             "name": "maxFee",


### PR DESCRIPTION
Do not merge until the solana production is updated.

This updates the settlement calls to the latest spoke upgrade where recipient accounts will be created if not exists.