### PR TITLE
fix: update deposit queue handling to use block numbers instead of epochs

### DIFF
--- a/packages/adapters/subgraph/src/lib/helpers/parse.ts
+++ b/packages/adapters/subgraph/src/lib/helpers/parse.ts
@@ -380,6 +380,7 @@ export const depositQueue = (entity: DepositQueueEntity): DepositQueue => {
     type: QueueType.Deposit,
     tickerHash: entity.tickerHash,
     epoch: StringToNumber(entity.epoch),
+    blockNumber: StringToNumber(entity.blockNumber),
   };
 };
 

--- a/packages/adapters/subgraph/src/lib/operations/entities.ts
+++ b/packages/adapters/subgraph/src/lib/operations/entities.ts
@@ -596,6 +596,7 @@ export const DEPOSIT_QUEUE_ENTITY = `
     size
     first
     last
+    blockNumber
 `;
 
 export type HubInvoiceEntity = {

--- a/packages/adapters/subgraph/src/lib/operations/queries.ts
+++ b/packages/adapters/subgraph/src/lib/operations/queries.ts
@@ -353,7 +353,7 @@ export const getDepositsProcessedQuery = (
 };
 
 export const getDepositQueuesQuery = (
-  fromEpoch: number,
+  fromBlock: number,
   maxBlockNumber?: number,
   limit = 200,
   orderDirection: 'asc' | 'desc' = 'asc',
@@ -361,11 +361,11 @@ export const getDepositQueuesQuery = (
   return `
     depositQueues(
       where: {
-        epoch_gte: ${fromEpoch}
+        blockNumber_gte: ${fromBlock}
         ${maxBlockNumber ? `, blockNumber_lte: ${maxBlockNumber}` : ''}
       },
       first: ${limit},
-      orderBy: epoch,
+      orderBy: blockNumber,
       orderDirection: ${orderDirection}
     ) {
       ${DEPOSIT_QUEUE_ENTITY}

--- a/packages/adapters/subgraph/src/reader.ts
+++ b/packages/adapters/subgraph/src/reader.ts
@@ -228,10 +228,10 @@ export class SubgraphReader {
     return queues;
   }
 
-  public async getDepositQueues(hubDomain: string, fromEpoch: number): Promise<DepositQueue[]> {
+  public async getDepositQueues(hubDomain: string, fromBlock: number): Promise<DepositQueue[]> {
     const { parser } = getHelpers();
     const response = await this.query<{ depositQueues: DepositQueueEntity[]; _meta: MetaEntity }>(hubDomain, [
-      getDepositQueuesQuery(fromEpoch),
+      getDepositQueuesQuery(fromBlock),
     ]);
 
     const queues = (response?.data.depositQueues ?? []).map((e) => parser.depositQueue(e));

--- a/packages/adapters/subgraph/test/reader.spec.ts
+++ b/packages/adapters/subgraph/test/reader.spec.ts
@@ -257,6 +257,7 @@ describe('SubgraphReader', () => {
       last: 11,
       epoch: 12321,
       tickerHash: mkBytes32('0x1'),
+      blockNumber: 123,
     };
     queue.id = `${queue.epoch}-${queue.domain}-${queue.tickerHash}`;
 

--- a/packages/agents/cartographer/poller/src/lib/operations/monitor.ts
+++ b/packages/agents/cartographer/poller/src/lib/operations/monitor.ts
@@ -5,7 +5,7 @@ import {
   TMessageType,
   TSettlementMessageType,
   createLoggingContext,
-  getMaxEpoch,
+  getMaxBlockNumber,
   getMaxTxNonce,
 } from '@chimera-monorepo/utils';
 
@@ -134,8 +134,8 @@ export const updateQueues = async () => {
 
   // Deposit queues are configured by `epoch-origin_domain-tickerhash`
   // There could be many more deposit queues than message queues, so these require a checkpoint
-  const prevEpoch = await database.getCheckPoint('hub_queue_deposit');
-  const depositQueues = await subgraph.getDepositQueues(config.hub.domain, prevEpoch);
+  const prevBlock = await database.getCheckPoint('hub_queue_deposit');
+  const depositQueues = await subgraph.getDepositQueues(config.hub.domain, prevBlock);
   logger.debug('Retrieved deposit queues', requestContext, methodContext, {
     depositQueues
   });
@@ -152,9 +152,9 @@ export const updateQueues = async () => {
     queues: new Set(queues.map((q) => q.id)).size,
   });
 
-  const latestEpoch = getMaxEpoch(depositQueues);
-  await database.saveCheckPoint('hub_queue_deposit', latestEpoch);
-  logger.debug('Saved checkpoint', requestContext, methodContext, { latestEpoch });
+  const latestBlock = getMaxBlockNumber(depositQueues);
+  await database.saveCheckPoint('hub_queue_deposit', latestBlock);
+  logger.debug('Saved checkpoint', requestContext, methodContext, { latestBlock });
 
   logger.debug('Method complete', requestContext, methodContext, {
     queues: queues.map((q) => ({ id: q.id, domain: q.domain, size: q.size, lastProcessed: q.lastProcessed })),

--- a/packages/agents/lighthouse/src/tasks/invoice/processDepositsAndInvoices.ts
+++ b/packages/agents/lighthouse/src/tasks/invoice/processDepositsAndInvoices.ts
@@ -47,8 +47,8 @@ export const processDepositsAndInvoices = async () => {
     assets: chains.assets,
   });
 
-  // Get all the configured asset tickers
-  const tickers = getConfiguredTickers(chains);
+  // Get all the configured asset tickers excluding native assets
+  const tickers = getConfiguredTickers(chains, true);
   const tickerHashes = getTickerHashes(tickers);
   logger.info('Configured tickers', requestContext, methodContext, { tickers, tickerHashes });
 

--- a/packages/subgraph/src/everclear-hub/mapping/intent.ts
+++ b/packages/subgraph/src/everclear-hub/mapping/intent.ts
@@ -137,7 +137,7 @@ function getOrCreateDeposit(id: Bytes, amount: BigInt, epoch: BigInt, domain: Bi
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-function getOrCreateDepositQueue(epoch: BigInt, domain: BigInt, tickerHash: Bytes): DepositQueue {
+function getOrCreateDepositQueue(epoch: BigInt, domain: BigInt, tickerHash: Bytes, blockNumber: BigInt): DepositQueue {
   const id = Bytes.fromByteArray(Bytes.fromBigInt(epoch).concat(Bytes.fromBigInt(domain))).concat(tickerHash);
   let queue = DepositQueue.load(id);
   if (queue == null) {
@@ -148,6 +148,7 @@ function getOrCreateDepositQueue(epoch: BigInt, domain: BigInt, tickerHash: Byte
     queue.first = BigInt.fromI32(1);
     queue.last = BigInt.zero();
     queue.size = BigInt.zero();
+    queue.blockNumber = blockNumber;
     queue.save();
   }
   return queue;
@@ -424,7 +425,7 @@ export function handleDepositEnqueued(event: DepositEnqueued): void {
   const intentId = event.params._intentId;
 
   // Update Deposit Queue
-  const queue = getOrCreateDepositQueue(event.params._epoch, event.params._domain, event.params._tickerHash);
+  const queue = getOrCreateDepositQueue(event.params._epoch, event.params._domain, event.params._tickerHash, event.block.number);
   queue.last = queue.last.plus(BigInt.fromI32(1));
   queue.size = queue.size.plus(BigInt.fromI32(1));
   queue.save();

--- a/packages/utils/src/helpers/db.ts
+++ b/packages/utils/src/helpers/db.ts
@@ -13,3 +13,7 @@ export const getMaxTxNonce = (items: { txNonce: number }[]): number => {
 export const getMaxEpoch = (items: { epoch: number }[]): number => {
   return items.length == 0 ? 0 : Math.max(...items.map((item) => item?.epoch ?? 0));
 };
+
+export const getMaxBlockNumber = (items: { blockNumber: number }[]): number => {
+  return items.length == 0 ? 0 : Math.max(...items.map((item) => item?.blockNumber ?? 0));
+};

--- a/packages/utils/src/helpers/ticker.ts
+++ b/packages/utils/src/helpers/ticker.ts
@@ -57,7 +57,13 @@ export const getConfiguredTickers = (chains: Record<string, ChainConfig>) => {
   const tickers = new Set<string>();
   domains.forEach((domain) => {
     const configured = Object.keys(chains[domain].assets ?? {});
-    configured.forEach((ticker: string) => tickers.add(ticker));
+    configured.forEach((ticker: string) => {
+      const asset = chains[domain].assets?.[ticker];
+      // Only add non-native assets
+      if (asset && !asset.isNative) {
+        tickers.add(ticker);
+      }
+    });
   });
   // Error if no tickers are configured for settlement.
   if (tickers.size === 0) {

--- a/packages/utils/src/helpers/ticker.ts
+++ b/packages/utils/src/helpers/ticker.ts
@@ -50,7 +50,7 @@ export const getTickerFromAssetContext = (domain: string, assetId: string, chain
   return ticker;
 };
 
-export const getConfiguredTickers = (chains: Record<string, ChainConfig>) => {
+export const getConfiguredTickers = (chains: Record<string, ChainConfig>, skipNativeAssets: boolean = false) => {
   // Get all the domains
   const domains = Object.keys(chains);
   // Get all the configured asset tickers
@@ -59,9 +59,13 @@ export const getConfiguredTickers = (chains: Record<string, ChainConfig>) => {
     const configured = Object.keys(chains[domain].assets ?? {});
     configured.forEach((ticker: string) => {
       const asset = chains[domain].assets?.[ticker];
-      // Only add non-native assets
-      if (asset && !asset.isNative) {
-        tickers.add(ticker);
+      if (asset) {
+        if (skipNativeAssets) {
+          // Only add non-native assets
+          if (!asset.isNative) tickers.add(ticker);
+        } else {
+          tickers.add(ticker);
+        }
       }
     });
   });

--- a/packages/utils/src/types/db.ts
+++ b/packages/utils/src/types/db.ts
@@ -239,6 +239,9 @@ export type HubDeposit = Static<typeof HubDepositSchema>;
 export const DepositQueueSchema = Type.Intersect([
   MessageQueueSchema,
   Type.Object({
+    blockNumber: Type.Integer(),
+  }),
+  Type.Object({
     type: Type.Literal(QueueType.Deposit),
     tickerHash: TBytes32,
     epoch: Type.Integer(),


### PR DESCRIPTION
update deposit queue handling to use block numbers instead of epochs