### PR TITLE
fix: emit declaration map for ts builds

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -50,7 +50,7 @@
 
     /* Emit */
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    "declarationMap": true,                              /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */


### PR DESCRIPTION
This allows LSP to resolves for source definition without searching *.d.ts files.

# 🤖 Linear
Closes CONG-XXX
    