### PR TITLE
revert: comment out Gelato relayer configuration in production settings

### DIFF
--- a/ops/mainnet/prod/core/config.tf
+++ b/ops/mainnet/prod/core/config.tf
@@ -540,11 +540,11 @@ locals {
       port = module.monitor_cache.redis_instance_port
     }
     relayers = [
-      # {
-      #   type   = "Gelato",
-      #   apiKey = "${var.gelato_api_key}",
-      #   url    = "https://relay.gelato.digital"
-      # },
+      {
+        type   = "Gelato",
+        apiKey = "${var.gelato_api_key}",
+        url    = "https://relay.gelato.digital"
+      },
       {
         type   = "Everclear",
         apiKey = "${var.admin_token_relayer}",
@@ -592,11 +592,11 @@ locals {
     environment = "production"
     network = "mainnet"
     relayers = [
-      # {
-      #   type   = "Gelato",
-      #   apiKey = "${var.gelato_api_key}",
-      #   url    = "https://relay.gelato.digital"
-      # },
+      {
+        type   = "Gelato",
+        apiKey = "${var.gelato_api_key}",
+        url    = "https://relay.gelato.digital"
+      },
       {
         type   = "Everclear",
         apiKey = "${var.admin_token_relayer}",


### PR DESCRIPTION
This reverts commit 6d51a8fd2867913c719bcd2a2e07ef773e39ab8d.
