### PR TITLE
fix: handle solana rpc errors better

### DIFF
--- a/ops/env/mainnet/backend/secrets.prod.json
+++ b/ops/env/mainnet/backend/secrets.prod.json
@@ -10,6 +10,7 @@
 	"drpc_key": "ENC[AES256_GCM,data:eJBSM3nx3Uj00YHDvBpbSxTUYa3o50icj5A94oNOHjBPLdX0/whbxGmsJms=,iv:ZK/GYGgAGiUF54vnlX5Zmkny/rdMYZGXCQ7ZEuzj420=,tag:uHS93Ah98tA0mryYM23IIA==,type:str]",
 	"alchemy_key": "ENC[AES256_GCM,data:rsy4DX9xKGbZ2fTHibff4T6lJwxw4KJwUiTPcCjfdV4=,iv:Lqc0kDyDMUSjGidTRvaf6mE7YU+SEfVMVGh+E7Aw8Yw=,tag:5bwjuACbJxxeqxc8cPP7FQ==,type:str]",
 	"gelato_everclear_rpc_key": "ENC[AES256_GCM,data:6yg8jKVc5qSOuUnnQ1P8LPpPcB85Le1xKdme4OVASUo=,iv:+H0h/ASAgwX6FOHJYieGyxi4H3ss0ppjv9v51yim964=,tag:WBu/qVULPM6AOMojREdw3A==,type:str]",
+	"quicknode_api_key": "ENC[AES256_GCM,data:Qi67mgx8JXpvBJSp4FfmMfAkYsIroDrU9c2F4q8DT9QWu/OQbKi38A==,iv:8jOjeJwVsIulvbKIAzi+IXNX+mKzcl0AN2B2DOFdRg0=,tag:F4bx8VaJ/BHF4za/pq3Isw==,type:str]",
 	"postgrest_jwt_secret": "ENC[AES256_GCM,data:FZX5PF8Rrd//9bkAXpFfBRmEBzTOhwcQbSkwBjNSbLLVp+WvnF3Vxm/Jyg==,iv:fenu90gIxSXhhit2212MUaEsm10Nv4vuPoJr8PJK7LU=,tag:LsoZP+h7yuzNyWZW4l+wmA==,type:str]",
 	"sops": {
 		"kms": [
@@ -24,8 +25,8 @@
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2025-05-29T07:41:12Z",
-		"mac": "ENC[AES256_GCM,data:pdIhUdBGwn+W76up35VWaTQkQOY/YwodBara7LPWsaNfK2t/Wm07gyoHG6CSWWu51Cu1iuOofoo6yzSYXSXRmppcJM28g8ccdHU7CBh8xmGfKpgYbKY4TElYngnrFjtKLQlQK+DWJ+eP12ykRwLIJRO2xHihKC1S8tk9vLbJ+98=,iv:deiurv41JtyNx4aEGxgHgOnd2SM3bMNZg54VQZ/5dvA=,tag:BxB/E35ARzKxXtE0izV6Eg==,type:str]",
+		"lastmodified": "2025-07-25T18:31:13Z",
+		"mac": "ENC[AES256_GCM,data:fUF6MMB1luYjR8MRdi3a6XTxgkrDZ/sIvPkAAhxIjO4D/68rodtag/eW4JUH4d2rQlFRSNpBHHectFPBu+/ASt09kjZu/Fs+4pXThPYShK9u/ANzYjONazz94raSUQqSGkr4Y5XJqj163od5Sf07uqPkp5RdOUa5fKc1sckP6K8=,iv:CZcfInQecS1na4kuAKd1YPBApkMIUtQKNRQQ/jg2e8k=,tag:NWiWNCrd6BHGcMdnUbKITQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.9.0"

--- a/ops/env/mainnet/core/secrets.prod.json
+++ b/ops/env/mainnet/core/secrets.prod.json
@@ -28,6 +28,7 @@
 	"betteruptime_requester_email": "ENC[AES256_GCM,data:YrTvQEHiPPigbAnJS7AmOQvy7N2wgHs=,iv:82OxZz1x1a936Xrt7+VbTVZkWTcxCZ8bhrZAYEEfUOM=,tag:Kcizl678RPBY/i2w0pwjMA==,type:str]",
 	"betteruptime_api_key": "ENC[AES256_GCM,data:MIGiOGdq18mrqIxfcTa1ebOCDPcj1leq,iv:y8cuv7Hvh3tXH047VIghAvoPPdiQCtV6BvfGYGj9QFc=,tag:5BWatkgJHkvURwf4oCYIIw==,type:str]",
 	"coingecko_api_key": "ENC[AES256_GCM,data:/Fy4okKDDfIErbbrjaxUto2FyokLhdWWM9K2,iv:+2HeRMhFbwbj+I+iAm8H/IJGxpB1RwwWPnVaFN2u2bM=,tag:lDxm0e+/wv8Ob5rwvoZ81A==,type:str]",
+	"quicknode_api_key": "ENC[AES256_GCM,data:Y+ExCNI2msRAT3FPy0yLCSAKm9NmXAZ15wb2fnwrmV5FAA1IfY7Xig==,iv:d4sWPsRoMchoN6auB2adAqrwl+nEmvR3bWa7Ghj9Qo0=,tag:7kZ7ox630tTy3dmYnw5zZg==,type:str]",
 	"solana_signer": "ENC[AES256_GCM,data:dqFUaf+ASQfn6rYlFinPZ8B16XcPaIGkCzweAEKr/m0qpQe93y2jlM4EkhgdcfMNKETXtQn1CHnQCux7dtyaCOyDkYEyT2/LHTqqo+Dolz00HsOxiQlyJwj9xya/GB+Ny8Pzo7j7W45VQcAebntnkQ8y/udx85NThG7mMxx8K9P9I+leNbDhC6wfGmKjZIbjvTx0nlsJPNNLgrNvVOpk3dFb1e2hy0Wfo3adOBri/dq9HzmxiR3CDton/J56GaonsnAqpTy2wlKu4HFsnvHENMTVtXYcfhu6pEdwbhFeWq5qpS8DoM3lJCrdoQ==,iv:CI3OyV/Z17n65l0BYuucq8jRwvuD4M5g+WAEDOUZ3rw=,tag:CdV6ijGAOrNAJyzUUDo1Zg==,type:str]",
 	"sops": {
 		"kms": [
@@ -42,8 +43,8 @@
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2025-04-15T16:32:03Z",
-		"mac": "ENC[AES256_GCM,data:kpHP+Ot+wduxv6JJ0AD5uYcXiAKOLftMCFAMPF2U9iEafZeVljJElGkSYlTCEmjygnQTXVYFT++aViO1VCh8MkJpE09sdg16nyjrXl3BzGUjMiWrCErRBNYG3qYM5seMphmbbZMH9OwQfqYsnB060Vcp/hTiiiu+HLs3EWEEx1k=,iv:/4GgZu8fOcVRvNnBzHiOTSE7NfBuOUlzk/s5dcR9mtQ=,tag:BNAb4AhSxnwWoO89WQ5KjQ==,type:str]",
+		"lastmodified": "2025-07-25T18:31:03Z",
+		"mac": "ENC[AES256_GCM,data:sqibOwW7CCd15s6H5o2KWpfArPJIePtOyJtrXEhuBUWxjU6MSR1aDW81nLWFTtK4U2nOG4HhtbXbqAA5Nfg90IGjXbMjlrfZnFnLqnC9betDL87I/YeRk7mR1iO0dQrjAGsc4YbDNai96QOosC80x1OFpNecSWDaJf6rHkVgbmc=,iv:peuudoDIzuMQLqyzuHqrXM3+PJz/rfQleNhNTeYmXd4=,tag:hNfidIzSegXzm8nDW49nZg==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.9.1"

--- a/ops/mainnet/prod/backend/config.tf
+++ b/ops/mainnet/prod/backend/config.tf
@@ -146,6 +146,7 @@ locals {
       },
       "1399811149" = {
         providers = [
+          "https://greatest-multi-market.solana-mainnet.quiknode.pro/${var.quicknode_api_key}/",
           "https://api.mainnet-beta.solana.com"
         ],
         network = "solana"

--- a/ops/mainnet/prod/backend/variables.tf
+++ b/ops/mainnet/prod/backend/variables.tf
@@ -109,3 +109,9 @@ variable "alchemy_key" {
   sensitive = true
   default   = "neverclear"
 }
+
+variable "quicknode_api_key" {
+  type      = string
+  sensitive = true
+  default   = "neverclear"
+}

--- a/ops/mainnet/prod/core/config.tf
+++ b/ops/mainnet/prod/core/config.tf
@@ -193,6 +193,7 @@ locals {
       },
       "1399811149" = {
         providers = [
+          "https://greatest-multi-market.solana-mainnet.quiknode.pro/${var.quicknode_api_key}/",
           "https://api.mainnet-beta.solana.com"
         ]
       },
@@ -352,6 +353,7 @@ locals {
       },
       "1399811149" = {
         providers = [
+          "https://greatest-multi-market.solana-mainnet.quiknode.pro/${var.quicknode_api_key}/",
           "https://api.mainnet-beta.solana.com"
         ]
       }
@@ -496,6 +498,7 @@ locals {
       },
       "1399811149" = {
         providers = [
+          "https://greatest-multi-market.solana-mainnet.quiknode.pro/${var.quicknode_api_key}/",
           "https://api.mainnet-beta.solana.com"
         ]
       },
@@ -736,6 +739,7 @@ locals {
       },
       "1399811149" = {
         providers = [
+          "https://greatest-multi-market.solana-mainnet.quiknode.pro/${var.quicknode_api_key}/",
           "https://api.mainnet-beta.solana.com"
         ]
       },

--- a/ops/mainnet/prod/core/variables.tf
+++ b/ops/mainnet/prod/core/variables.tf
@@ -258,6 +258,12 @@ variable "coingecko_api_key" {
   default = "neverclear"
 }
 
+variable "quicknode_api_key" {
+  type      = string
+  sensitive = true
+  default = "neverclear"
+}
+
 variable "lighthouse_solana_heartbeat" {
   type      = string
   sensitive = true

--- a/packages/agents/monitor/src/checklist/rpc.ts
+++ b/packages/agents/monitor/src/checklist/rpc.ts
@@ -53,7 +53,7 @@ export const checkRpcs = async () => {
 
   for (const badRpc of badRpcs) {
     // Skip alerts for Solana 429 errors
-    if (badRpc.domain === SOLANA_CHAINID && badRpc.error?.includes('429')) {
+    if (String(badRpc.domain) === String(SOLANA_CHAINID) && badRpc.error?.includes('429')) {
       continue;
     }
 

--- a/packages/agents/monitor/src/checklist/rpc.ts
+++ b/packages/agents/monitor/src/checklist/rpc.ts
@@ -1,7 +1,7 @@
 import { providers } from 'ethers';
-import { createLoggingContext, Logger } from '@chimera-monorepo/utils';
+import { createLoggingContext, Logger, Severity, SOLANA_CHAINID } from '@chimera-monorepo/utils';
 import { getContext } from '../context';
-import { Report, Severity } from '../types';
+import { Report } from '../types';
 import { resolveAlerts, sendAlerts } from '../mockable';
 import { Connection } from '@solana/web3.js';
 
@@ -52,6 +52,11 @@ export const checkRpcs = async () => {
   }
 
   for (const badRpc of badRpcs) {
+    // Skip alerts for Solana 429 errors
+    if (badRpc.domain === SOLANA_CHAINID && badRpc.error?.includes('429')) {
+      continue;
+    }
+
     const report = makeReport(badRpc, logger, config.environment);
     await sendAlerts(report, logger, config, requestContext);
   }


### PR DESCRIPTION
 handle solana rpc errors better
This pull request introduces the integration of QuickNode API keys into the configuration for Solana network providers and updates the monitoring logic to handle specific Solana RPC errors. The changes span multiple files and include updates to secrets, configurations, and monitoring logic.

### Configuration Updates for QuickNode Integration:
* Added `quicknode_api_key` to `ops/env/mainnet/backend/secrets.prod.json` and `ops/env/mainnet/core/secrets.prod.json` to securely store the API key. [[1]](diffhunk://#diff-2e3216c3e0d09c70891e4d833b1b156abb0c54521257278ba96611e859732d5cR13) [[2]](diffhunk://#diff-eb95510d49c95a2f858f8b70c3b11c73845ad0579c2e0e9658051a033004de9fR31)
* Updated `locals` in `ops/mainnet/prod/backend/config.tf` and `ops/mainnet/prod/core/config.tf` to include QuickNode URLs as Solana network providers. [[1]](diffhunk://#diff-ea8109514f7457458fc9b42640c131ff68c5a5c2d964644d66e45f5e1807e1b4R149) [[2]](diffhunk://#diff-cf6a97c2af3dfcab783bb2e71fb1ee9517cb42375988b7ba2d18b80bccc9150bR196) [[3]](diffhunk://#diff-cf6a97c2af3dfcab783bb2e71fb1ee9517cb42375988b7ba2d18b80bccc9150bR356) [[4]](diffhunk://#diff-cf6a97c2af3dfcab783bb2e71fb1ee9517cb42375988b7ba2d18b80bccc9150bR501) [[5]](diffhunk://#diff-cf6a97c2af3dfcab783bb2e71fb1ee9517cb42375988b7ba2d18b80bccc9150bR742)
* Added `quicknode_api_key` as a new variable in `ops/mainnet/prod/backend/variables.tf` and `ops/mainnet/prod/core/variables.tf`. [[1]](diffhunk://#diff-69887a79ec85eaef8bc361e901af15d6a30a1858067f69e1ceea83c176d4b31cR112-R117) [[2]](diffhunk://#diff-f15a934210c4d33f943cde54ce78ab64f20e8624488cae4cc9cfaa55df3dd51eR261-R266)

### Monitoring Enhancements:
* Updated `packages/agents/monitor/src/checklist/rpc.ts` to skip alerts for Solana RPC 429 errors, preventing unnecessary notifications.
* Imported `SOLANA_CHAINID` from `@chimera-monorepo/utils` to identify Solana-specific RPC issues.

### Metadata Updates:
* Updated the `lastmodified` and `mac` fields in the secrets files to reflect the latest changes. [[1]](diffhunk://#diff-2e3216c3e0d09c70891e4d833b1b156abb0c54521257278ba96611e859732d5cL27-R29) [[2]](diffhunk://#diff-eb95510d49c95a2f858f8b70c3b11c73845ad0579c2e0e9658051a033004de9fL45-R47)