### PR TITLE
fix: temporary disable checkChains

### DIFF
--- a/packages/agents/monitor/src/checklist/index.ts
+++ b/packages/agents/monitor/src/checklist/index.ts
@@ -25,7 +25,7 @@ import { checkSolanaPipelineStatus } from './solana';
 export const runChecks = async () => {
   const { requestContext, methodContext } = createLoggingContext(runChecks.name);
   const checklist = [
-    checkChains,
+    // checkChains,
     checkAgents,
     checkMessageStatus,
     checkRpcs,

--- a/packages/agents/monitor/test/checklist/index.spec.ts
+++ b/packages/agents/monitor/test/checklist/index.spec.ts
@@ -63,7 +63,7 @@ describe('runChecks', () => {
 
     await runChecks();
 
-    expect(chainsStub.calledOnce).to.be.true;
+    // expect(chainsStub.calledOnce).to.be.true;
     expect(agentsStub.calledOnce).to.be.true;
     expect(rpcStub.calledOnce).to.be.true;
     expect(checkSpokeBalanceStub.calledOnce).to.be.true;


### PR DESCRIPTION
disable `checkChains` temporary to make monitor works

right now it consumes too much runtime and makes monitor timeout. need further investigation as with which provider are lagging