### PR TITLE
fix: use onchain getCurrentEpoch directly for epoch calculation

### DIFF
--- a/packages/agents/lighthouse/src/tasks/invoice/processDepositsAndInvoices.ts
+++ b/packages/agents/lighthouse/src/tasks/invoice/processDepositsAndInvoices.ts
@@ -91,21 +91,18 @@ export const processDepositsAndInvoices = async () => {
       encodedDataForLastClosedEpochRes,
     );
 
-    const encodedDataForEpochLength = iface.encodeFunctionData('epochLength', []);
-    const encodedDataForEpochLengthRes = await chainservice.readTx(
+    const encodedDataForGetCurrentEpoch = iface.encodeFunctionData('getCurrentEpoch', []);
+    const encodedDataForGetCurrentEpochRes = await chainservice.readTx(
       {
         to: hub.deployments.everclear,
         domain: +hub.domain,
-        data: encodedDataForEpochLength,
-        funcSig: iface.getFunction('epochLength').format(),
+        data: encodedDataForGetCurrentEpoch,
+        funcSig: iface.getFunction('getCurrentEpoch').format(),
       },
       'latest',
     );
-    const [epochLength] = iface.decodeFunctionResult('epochLength', encodedDataForEpochLengthRes);
+    const [currentEpoch] = iface.decodeFunctionResult('getCurrentEpoch', encodedDataForGetCurrentEpochRes);
 
-    // NOTE: Use L1 block to compute current epoch, as getBlockNumber(+hub.domain) returns L2 block
-    const blockNumber = await chainservice.getBlockNumber(1);
-    const currentEpoch = Math.floor(blockNumber / +epochLength.toString());
     const lastClosedEpoch = currentEpoch > 0 ? currentEpoch - 1 : 0;
     // Check if there are deposits to process in unprocessed epochs across all spokes
     let hasDepositsToProcess = false;
@@ -147,8 +144,6 @@ export const processDepositsAndInvoices = async () => {
         tickerHash,
         invoices: invoices.length,
         lastClosedEpochProcessed: lastClosedEpochProcessed.toString(),
-        blockNumber,
-        epochLength,
         currentEpoch,
         lastClosedEpoch,
         hasInvoicesToProcess,

--- a/packages/agents/lighthouse/test/tasks/invoice/processDepositsAndInvoices.spec.ts
+++ b/packages/agents/lighthouse/test/tasks/invoice/processDepositsAndInvoices.spec.ts
@@ -127,13 +127,10 @@ describe('#processDepositsAndInvoices', () => {
     decodeFunctionResult.onCall(0).returns({head: mkBytes32(), tail: mkBytes32(), length: 0, nodes: {}});
 
     // Mock iface.decodeFunctionResult('lastClosedEpochsProcessed', ...);
-    decodeFunctionResult.onCall(1).returns([[3]]);
+    decodeFunctionResult.onCall(1).returns([[24]]);
 
-    // Mock iface.decodeFunctionResult('lastClosedEpochsProcessed', ...);
+    // Mock iface.decodeFunctionResult('getCurrentEpoch', ...);
     decodeFunctionResult.onCall(2).returns([BigNumber.from(25)]);
-
-    // Mock chainservice.getBlockNumber
-    chainservice.getBlockNumber.resolves(100);
 
     await processDepositsAndInvoices();
 


### PR DESCRIPTION
the previous epoch calculation ignored epochLength updates which leads to incorrect value being calculated. instead we should use getCurrentEpoch directly for the correct value

# 🤖 Linear
Closes CONG-XXX
    