### PR TITLE
fix: pause handling

### DIFF
--- a/packages/subgraph/src/everclear-hub/mapping/meta.ts
+++ b/packages/subgraph/src/everclear-hub/mapping/meta.ts
@@ -10,6 +10,8 @@ import {
   MinSolverSupportedDomainsUpdated,
   ExpiryTimeBufferUpdated,
   EpochLengthUpdated,
+  Paused as PausedEvent,
+  Unpaused as UnpausedEvent,
 } from '../../../generated/EverclearHub/EverclearHub';
 import { getChainId } from '../../common';
 
@@ -72,9 +74,8 @@ export function handleOwnershipTransferred(event: OwnershipTransferred): void {
  *
  * @param event - The contract event used to create the subgraph record
  */
-export function handlePaused(): void {
+export function handlePaused(event: PausedEvent): void {
   const meta = getOrCreateMeta();
-
   meta.paused = true;
   meta.save();
 }
@@ -84,9 +85,8 @@ export function handlePaused(): void {
  *
  * @param event - The contract event used to create the subgraph record
  */
-export function handleUnpaused(): void {
+export function handleUnpaused(event: UnpausedEvent): void {
   const meta = getOrCreateMeta();
-
   meta.paused = false;
   meta.save();
 }

--- a/packages/subgraph/src/everclear-spoke/mapping/meta.ts
+++ b/packages/subgraph/src/everclear-spoke/mapping/meta.ts
@@ -5,6 +5,8 @@ import {
   MessageReceiverUpdated,
   ModuleSetForStrategy,
   StrategySetForAsset,
+  Paused as PausedEvent,
+  Unpaused as UnpausedEvent,
 } from '../../../generated/EverclearSpoke/EverclearSpoke';
 import { FeeRecipientUpdated as FeeRecipientUpdatedEvent } from '../../../generated/FeeAdapter/FeeAdapter';
 import { Meta, ModuleForStrategy, StrategyForAsset, FeeRecipientUpdated } from '../../../generated/schema';
@@ -35,7 +37,7 @@ export function getOrCreateMeta(): Meta {
  *
  * @param event - The contract event used to create the subgraph record
  */
-export function handlePaused(): void {
+export function handlePaused(event: PausedEvent): void {
   const meta = getOrCreateMeta();
   meta.paused = true;
   meta.save();
@@ -46,7 +48,7 @@ export function handlePaused(): void {
  *
  * @param event - The contract event used to create the subgraph record
  */
-export function handleUnpaused(): void {
+export function handleUnpaused(event: UnpausedEvent): void {
   const meta = getOrCreateMeta();
   meta.paused = false;
   meta.save();


### PR DESCRIPTION
# 🤖 Linear
Fixing the paused and unpaused errors being thrown by the handlers in Spoke and Hub Subgraphs.
    