### PR TITLE
fix: change priority to use everclear relayer before gelato

### DIFF
--- a/ops/mainnet/prod/core/config.tf
+++ b/ops/mainnet/prod/core/config.tf
@@ -535,14 +535,14 @@ locals {
     }
     relayers = [
       {
-        type   = "Gelato",
-        apiKey = "${var.gelato_api_key}",
-        url    = "https://relay.gelato.digital"
-      },
-      {
         type   = "Everclear",
         apiKey = "${var.admin_token_relayer}",
         url    = "https://${module.relayer_server.service_endpoint}"
+      },
+      {
+        type   = "Gelato",
+        apiKey = "${var.gelato_api_key}",
+        url    = "https://relay.gelato.digital"
       }
     ]
     agents = {
@@ -587,14 +587,14 @@ locals {
     network = "mainnet"
     relayers = [
       {
-        type   = "Gelato",
-        apiKey = "${var.gelato_api_key}",
-        url    = "https://relay.gelato.digital"
-      },
-      {
         type   = "Everclear",
         apiKey = "${var.admin_token_relayer}",
         url    = "https://${module.relayer_server.service_endpoint}"
+      },
+      {
+        type   = "Gelato",
+        apiKey = "${var.gelato_api_key}",
+        url    = "https://relay.gelato.digital"
       }
     ]
     thresholds = {


### PR DESCRIPTION
merge only when ops team are ready

# 🤖 Linear
Closes CONG-XXX
    