### PR TITLE
fix: solana confirmation should return pos value for mine confirmation

### DIFF
--- a/packages/adapters/chainservice/src/shared/rpc/solana/provider.ts
+++ b/packages/adapters/chainservice/src/shared/rpc/solana/provider.ts
@@ -20,6 +20,8 @@ const TOKEN_PROGRAM_ID = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
 
 const SPL_ASSOCIATED_TOKEN_ACCOUNT_PROGRAM_ID = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL';
 
+// Assume a big enough number of confirmations and treat it as final.
+const SOLANA_MAX_CONFIRMATIONS = 1000;
 
 class SolanaWeb3Signer implements ISigner {
   constructor(
@@ -188,11 +190,12 @@ export class SolanaProvider implements RpcProvider {
     const result = await this.rpc.getTransaction(hash as Signature, {
       // NOTE: this is required to also support v0 transactions
       maxSupportedTransactionVersion: 0,
-      encoding: 'json'
+      encoding: 'json',
+      commitment: 'finalized',
     }).send();
     return {
       hash: hash,
-      confirmations: 0, // this is assume to only obtain finalized transactions
+      confirmations: result ? SOLANA_MAX_CONFIRMATIONS : 0,
       nonce: 0, // this is not used in solana
       gasPrice: '1', // assume 1 lamport per unit
       gasLimit: result?.meta?.fee?.toString() || '0',
@@ -214,13 +217,14 @@ export class SolanaProvider implements RpcProvider {
     const result = await this.rpc.getTransaction(hash as Signature, {
       // NOTE: this is required to also support v0 transactions
       maxSupportedTransactionVersion: 0,
-      encoding: 'json'
+      encoding: 'json',
+      commitment: 'finalized',
     }).send();
     return {
       blockNumber: Number(result?.slot) || 0,
       status: result?.meta?.err ? 0 : 1,
       transactionHash: hash,
-      confirmations: 0,
+      confirmations: result ? SOLANA_MAX_CONFIRMATIONS : 0,
       logs: result?.meta?.logMessages?.map((logLine, index) => {
         return {
           blockNumber: Number(result?.slot) || 0,

--- a/packages/adapters/chainservice/test/integration/solana/mine.spec.ts
+++ b/packages/adapters/chainservice/test/integration/solana/mine.spec.ts
@@ -1,0 +1,68 @@
+import { Logger, expect } from '@chimera-monorepo/utils';
+import { ChainService, OnchainTransaction, OperationTimeout, WriteTransaction } from '../../../src';
+import { TEST_REQUEST_CONTEXT } from '../../utils';
+
+// Integration test: construct TransactionDispatch and call its mine() against a predefined
+// Solana transaction signature provided via env SOLANA_TEST_SIGNATURE.
+
+describe('TransactionDispatch.mine', () => {
+  const logger = new Logger({ level: 'debug', name: 'TransactionDispatch.mine' });
+
+  const SOLANA_DOMAIN = 1399811149;
+  const SOLANA_RPC = process.env.SOLANA_RPC_URL || 'https://api.mainnet-beta.solana.com';
+  const SOLANA_TEST_SIGNATURE = process.env.SOLANA_TEST_SIGNATURE || '2XwniWnR7AEEC3eqLc1qxG7wxkqPyaFWBG8ymZDCEo4LmqJtNKkjCMZJiwwM5KnRFtndsGPWauCYLjTuWn4jZSQD';
+
+  it('calls mine on a predefined Solana tx hash', async function () {
+    this.timeout(90_000);
+
+    if (!SOLANA_TEST_SIGNATURE) {
+      this.skip();
+    }
+
+    const chainService = new ChainService(
+      logger.child({ module: 'ChainService' }),
+      {
+        [SOLANA_DOMAIN]: {
+          providers: [SOLANA_RPC],
+        },
+      },
+      // Global signer is irrelevant for reading receipts; provide a dummy
+      '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    );
+
+    expect(chainService).to.be.ok;
+
+    // Get underlying TransactionDispatch for Solana
+    const txDispatch = await chainService.getProvider(SOLANA_DOMAIN);
+
+    // Build an OnchainTransaction with the predefined hash in responses to satisfy didSubmit
+    const minTx: WriteTransaction = { value: '0' } as unknown as WriteTransaction;
+    const transaction = new OnchainTransaction(
+      TEST_REQUEST_CONTEXT,
+      minTx,
+      0,
+      { limit: '0', price: '0' },
+      { confirmationTimeout: 20_000, confirmationsRequired: 1 },
+      'solana_test_tx_uuid',
+    );
+
+    transaction.responses.push({
+      hash: SOLANA_TEST_SIGNATURE,
+      confirmations: 0,
+      nonce: 0,
+      gasPrice: '0',
+      gasLimit: '0',
+    });
+
+    try {
+      await (txDispatch as any).mine(transaction);
+      // With current Solana provider, confirmations remain 0, so reaching here would be unexpected
+      // but acceptable if the RPC reports confirmations differently. Assert we have a receipt shape.
+      expect(transaction.receipt).to.be.ok;
+      expect(transaction.receipt!.transactionHash).to.equal(SOLANA_TEST_SIGNATURE);
+    } catch (err) {
+      // Expected outcome: OperationTimeout due to 0 confirmations in Solana provider implementation
+      expect(err).to.be.instanceOf(OperationTimeout);
+    }
+  });
+});

--- a/packages/adapters/chainservice/test/unit/shared/rpc/solana.spec.ts
+++ b/packages/adapters/chainservice/test/unit/shared/rpc/solana.spec.ts
@@ -1,0 +1,150 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from '@chimera-monorepo/utils';
+import { restore, reset } from 'sinon';
+
+import { SolanaProvider } from '../../../../src/shared/rpc/solana/provider';
+
+describe('SolanaProvider', () => {
+  const SOLANA_NATIVE_ASSET_ID = '11111111111111111111111111111111';
+  const TEST_BLOCKHEIGHT = 12345;
+
+  let provider: SolanaProvider;
+  let mockRpc: any;
+
+  beforeEach(() => {
+    provider = new SolanaProvider('http://solana.test');
+
+    mockRpc = {
+      getBlockHeight: () => ({ send: async () => TEST_BLOCKHEIGHT }),
+      getTransaction: () => ({
+        send: async () => ({
+          slot: 42,
+          meta: { fee: 5000, err: null, logMessages: ['log-1', 'log-2'] },
+          transaction: { message: { recentBlockhash: 'recent-blockhash-abc' } },
+        }),
+      }),
+      getRecentPrioritizationFees: () => ({
+        send: async () => [
+          { prioritizationFee: 100n },
+          { prioritizationFee: 300n },
+        ],
+      }),
+      getBlock: () => ({
+        send: async () => ({
+          blockhash: 'blockhash-123',
+          previousBlockhash: 'parenthash-122',
+          blockHeight: 123,
+          blockTime: 1710000000,
+        }),
+      }),
+      getBalance: () => ({
+        send: async () => ({ value: 321n }),
+      }),
+      getTokenAccountBalance: () => ({
+        send: async () => ({ value: { amount: '999' } }),
+      }),
+      simulateTransaction: () => ({ send: async () => ({ value: { returnData: { data: '0x' } } }) }),
+    };
+
+    (provider as any).rpc = mockRpc;
+  });
+
+  afterEach(() => {
+    restore();
+    reset();
+  });
+
+  it('has correct default values', () => {
+    expect((provider as any).name).to.equal('SolanaProvider');
+    expect(provider.synced).to.be.false;
+    expect(provider.syncedBlockNumber).to.equal(0);
+    expect(provider.priority).to.equal(0);
+    expect(provider.lag).to.equal(0);
+    expect(provider.reliability).to.equal(1);
+    expect(provider.latency).to.equal(0);
+    expect(provider.cps).to.equal(0);
+  });
+
+  describe('#sync', () => {
+    it('should retrieve and set current block height', async () => {
+      await provider.sync();
+      expect(provider.synced).to.be.true;
+      expect(provider.syncedBlockNumber).to.equal(TEST_BLOCKHEIGHT);
+    });
+
+    it('should set synced=false and rethrow on error', async () => {
+      (provider as any).rpc.getBlockHeight = () => ({ send: async () => { throw new Error('rpc error'); } });
+      await expect(provider.sync()).to.be.rejectedWith('rpc error');
+      expect(provider.synced).to.be.false;
+    });
+  });
+
+  describe('#getTransaction', () => {
+    it('should format transaction response', async () => {
+      const res = await provider.getTransaction('sig-123');
+      expect(res).to.deep.equal({
+        hash: 'sig-123',
+        confirmations: 1000,
+        nonce: 0,
+        gasPrice: '1',
+        gasLimit: '5000',
+      });
+    });
+  });
+
+  describe('#getTransactionReceipt', () => {
+    it('should format receipt with logs', async () => {
+      const receipt = await provider.getTransactionReceipt('sig-abc');
+      expect(receipt.transactionHash).to.equal('sig-abc');
+      expect(receipt.blockNumber).to.equal(42);
+      expect(receipt.status).to.equal(1);
+      expect(receipt.confirmations).to.equal(1000);
+      expect(receipt.logs.length).to.equal(2);
+      expect(receipt.logs[0]).to.deep.include({
+        blockNumber: 42,
+        blockHash: 'recent-blockhash-abc',
+        transactionHash: 'sig-abc',
+        logIndex: 0,
+      });
+    });
+  });
+
+  describe('#getGasPrice', () => {
+    it('should return average recent prioritization fee', async () => {
+      const price = await provider.getGasPrice();
+      expect(price).to.equal('200'); // (100 + 300) / 2
+    });
+  });
+
+  describe('#getBlock', () => {
+    it('should return formatted block', async () => {
+      const block = await provider.getBlock(123);
+      expect(block).to.deep.equal({
+        hash: 'blockhash-123',
+        parentHash: 'parenthash-122',
+        number: 123,
+        timestamp: 1710000000,
+      });
+    });
+
+    it('should throw if block not found', async () => {
+      (provider as any).rpc.getBlock = () => ({ send: async () => undefined });
+      await expect(provider.getBlock(999)).to.be.rejectedWith('Block not found');
+    });
+  });
+
+  describe('#getBlockNumber', () => {
+    it('should return current block height', async () => {
+      (provider as any).rpc.getBlockHeight = () => ({ send: async () => 42n });
+      const n = await provider.getBlockNumber();
+      expect(n).to.equal(42);
+    });
+  });
+
+  describe('#getBalance', () => {
+    it('should return native SOL balance for system program id', async () => {
+      const bal = await provider.getBalance('SomeAddress', SOLANA_NATIVE_ASSET_ID);
+      expect(bal).to.equal('321');
+    });
+  });
+});


### PR DESCRIPTION
solana do not have a confirmation returns but rather its the request that specify confirmations. change the impl to force 'finalized' status (as we force 'confirmed' status during sending) and return 1000 blocks which should be large enough for checks

# 🤖 Linear
Closes CONG-XXX
    