### PR TITLE
fix: remove deprecated blastapi endpoint from mainnet configuration

### DIFF
--- a/ops/mainnet/prod/backend/config.tf
+++ b/ops/mainnet/prod/backend/config.tf
@@ -118,7 +118,6 @@ locals {
       },
       "34443" = {
         providers = [
-          "https://mode-mainnet.blastapi.io/${var.blast_key}",
           "https://mainnet.mode.network"
         ]
       },

--- a/ops/mainnet/prod/core/config.tf
+++ b/ops/mainnet/prod/core/config.tf
@@ -167,7 +167,6 @@ locals {
       },
       "34443" = {
         providers = [
-          "https://mode-mainnet.blastapi.io/${var.blast_key}",
           "https://mainnet.mode.network"
         ]
       },
@@ -322,7 +321,6 @@ locals {
       },
       "34443" = {
         providers = [
-          "https://mode-mainnet.blastapi.io/${var.blast_key}",
           "https://mainnet.mode.network"
         ]
       },
@@ -462,7 +460,6 @@ locals {
       },
       "34443" = {
         providers = [
-          "https://mode-mainnet.blastapi.io/${var.blast_key}",
           "https://mainnet.mode.network"
         ]
       },
@@ -703,7 +700,6 @@ locals {
       },
       "34443" = {
         providers = [
-          "https://mode-mainnet.blastapi.io/${var.blast_key}",
           "https://mainnet.mode.network"
         ]
       },


### PR DESCRIPTION
# 🤖 Linear
Closes CONG-XXX
    