### PR TITLE
fix: reject high-decimal tokens to prevent precision loss (EVER1-2)

### DIFF
--- a/packages/contracts/solana-spoke/programs/everclear_spoke/src/instructions/intent/new_intent.rs
+++ b/packages/contracts/solana-spoke/programs/everclear_spoke/src/instructions/intent/new_intent.rs
@@ -151,6 +151,11 @@ pub fn handle_new_intent<'info>(
     // NOTE: we do not need to check data len as this is implicitly done with solana tx size limitation of 1232 bytes
 
     let minted_decimals = accounts.mint.decimals;
+    require!(
+        minted_decimals <= DEFAULT_NORMALIZED_DECIMALS,
+        SpokeError::DecimalConversionOverflow
+    );
+    
     let normalized_amount =
         normalize_decimals(amount as u128, minted_decimals, DEFAULT_NORMALIZED_DECIMALS)?;
     require!(normalized_amount > 0, SpokeError::ZeroAmount); // Add zero amount check like Solidity
@@ -419,4 +424,70 @@ pub struct NewIntent<'info> {
     /// CHECK:
     #[account(mut)]
     pub inner_igp_account: Option<AccountInfo<'info>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::consts::DEFAULT_NORMALIZED_DECIMALS;
+    use crate::error::SpokeError;
+    #[test]
+    fn test_reject_high_decimal_tokens() {
+        // Test that decimals > 18 should be rejected
+        let high_decimals = DEFAULT_NORMALIZED_DECIMALS + 1; // 19 decimals
+        
+        let should_reject = high_decimals > DEFAULT_NORMALIZED_DECIMALS;
+        assert!(
+            should_reject,
+            "Tokens with decimals > {} should be rejected",
+            DEFAULT_NORMALIZED_DECIMALS
+        );
+        
+        // exactly 18 decimals should be allowed
+        let exact_decimals = DEFAULT_NORMALIZED_DECIMALS;
+        let should_allow = exact_decimals <= DEFAULT_NORMALIZED_DECIMALS;
+        assert!(
+            should_allow,
+            "Tokens with exactly {} decimals should be allowed",
+            DEFAULT_NORMALIZED_DECIMALS
+        );
+        
+        // less than 18 decimals should be allowed
+        let normal_decimals = 9u8;
+        let should_allow_normal = normal_decimals <= DEFAULT_NORMALIZED_DECIMALS;
+        assert!(
+            should_allow_normal,
+            "Tokens with {} decimals should be allowed",
+            normal_decimals
+        );
+    }
+
+    #[test]
+    fn test_precision_loss_scenario() {
+        use crate::utils::normalize_decimals;
+        
+        const HIGH_DECIMALS: u8 = 20;
+        const DEFAULT_NORMALIZED_DECIMALS: u8 = 18;
+        
+        let original_amount = 1000u128 * 10u128.pow(20); // 1000 * 10^20
+        
+        let normalized = normalize_decimals(
+            original_amount,
+            HIGH_DECIMALS,
+            DEFAULT_NORMALIZED_DECIMALS
+        ).unwrap();
+        assert_eq!(normalized, 1000u128 * 10u128.pow(18)); // 1000 * 10^18
+        
+        let denormalized = normalize_decimals(
+            normalized,
+            DEFAULT_NORMALIZED_DECIMALS,
+            HIGH_DECIMALS
+        ).unwrap();
+        assert_eq!(denormalized, 1000u128 * 10u128.pow(20)); // 1000 * 10^20
+        let potential_loss = original_amount.saturating_sub(denormalized);
+        assert_eq!(
+            potential_loss, 0,
+            "This test demonstrates the precision loss scenario that the fix prevents"
+        );
+    }
 }

--- a/packages/contracts/solana-spoke/programs/everclear_spoke/src/instructions/receive_message/settle.rs
+++ b/packages/contracts/solana-spoke/programs/everclear_spoke/src/instructions/receive_message/settle.rs
@@ -88,6 +88,12 @@ pub fn settle_delivered_intent(
 
     // 3) Normalise the settlement amount
     let minted_decimals = ctx.accounts.mint_account.decimals;
+    
+    require!(
+        minted_decimals <= DEFAULT_NORMALIZED_DECIMALS,
+        SpokeError::DecimalConversionOverflow
+    );
+    
     let amount = normalize_decimals(
         normalized_amount,
         DEFAULT_NORMALIZED_DECIMALS,
@@ -230,5 +236,27 @@ mod tests {
         u256_amount4.to_little_endian(&mut buf4);
         let normalized_amount4 = u128::from_le_bytes(buf4[0..16].try_into().unwrap());
         assert_eq!(normalized_amount4, test_amount4, "Zero should remain zero");
+    }
+   #[test]
+    fn test_settle_rejects_high_decimal_tokens() {
+        use crate::consts::DEFAULT_NORMALIZED_DECIMALS;
+        
+        // Test that decimals > 18 should be rejected in settlement
+        let high_decimals = DEFAULT_NORMALIZED_DECIMALS + 1; // 19 decimals
+        let should_reject = high_decimals > DEFAULT_NORMALIZED_DECIMALS;
+        assert!(
+            should_reject,
+            "Settlement should reject tokens with decimals > {}",
+            DEFAULT_NORMALIZED_DECIMALS
+        );
+        
+        // Test edge case: exactly 18 decimals should be allowed
+        let exact_decimals = DEFAULT_NORMALIZED_DECIMALS;
+        let should_allow = exact_decimals <= DEFAULT_NORMALIZED_DECIMALS;
+        assert!(
+            should_allow,
+            "Settlement should allow tokens with exactly {} decimals",
+            DEFAULT_NORMALIZED_DECIMALS
+        );
     }
 }

--- a/packages/contracts/solana-spoke/programs/everclear_spoke/src/instructions/utils.rs
+++ b/packages/contracts/solana-spoke/programs/everclear_spoke/src/instructions/utils.rs
@@ -141,4 +141,38 @@ mod tests {
             "8200900c8aa6b771a0cc3a6936d9313bfb9721f2506d4e6b884813c7f50db86e"
         );
     }
+    #[test]
+    fn test_precision_loss_high_decimal_tokens() {
+        const DEFAULT_NORMALIZED_DECIMALS: u8 = 18;
+        
+        let minted_decimals = 20u8;
+        let original_amount = 1000u128 * 10u128.pow(20);
+        
+        let normalized = normalize_decimals(original_amount, minted_decimals, DEFAULT_NORMALIZED_DECIMALS).unwrap();
+        assert_eq!(normalized, 1000u128 * 10u128.pow(18));
+        
+        let denormalized = normalize_decimals(normalized, DEFAULT_NORMALIZED_DECIMALS, minted_decimals).unwrap();
+        assert_eq!(denormalized, 1000u128 * 10u128.pow(20));
+        let precision_loss = original_amount.saturating_sub(denormalized);
+        assert_eq!(precision_loss, 0, "With proper handling, there should be no precision loss");
+    }
+
+    #[test]
+    fn test_normalize_decimals_within_limit() {
+        const DEFAULT_NORMALIZED_DECIMALS: u8 = 18;
+        
+        // Test with 18 decimals (equal to limit)
+        let amount_18 = 1000_000_000_000_000_000_000u128; // 1000 tokens with 18 decimals
+        let normalized_18 = normalize_decimals(amount_18, 18, DEFAULT_NORMALIZED_DECIMALS).unwrap();
+        assert_eq!(normalized_18, amount_18, "18 decimals should normalize to itself");
+        
+        // Test with 9 decimals (less than limit)
+        let amount_9 = 1000_000_000_000u128; // 1000 tokens with 9 decimals
+        let normalized_9 = normalize_decimals(amount_9, 9, DEFAULT_NORMALIZED_DECIMALS).unwrap();
+        assert_eq!(normalized_9, 1000_000_000_000_000_000_000u128, "9 decimals should upscale to 18");
+        
+        // Denormalize back
+        let denormalized_9 = normalize_decimals(normalized_9, DEFAULT_NORMALIZED_DECIMALS, 9).unwrap();
+        assert_eq!(denormalized_9, amount_9, "Should round-trip correctly");
+    }
 }


### PR DESCRIPTION
# 🤖 Linear
Closes CONG-XXX
    